### PR TITLE
Update go version

### DIFF
--- a/shooter/go.mod
+++ b/shooter/go.mod
@@ -1,6 +1,6 @@
 module theprimeagen.tv/shooter-js-analytics
 
-go 1.21.0
+go 1.21
 
 require github.com/labstack/echo/v4 v4.11.1
 


### PR DESCRIPTION
Using go 1.21.0 instead of go 1.21 is causing an error when setting up the repo